### PR TITLE
정건희[fix]: 근태관리 스케줄러 로직 수정

### DIFF
--- a/src/main/java/com/ga/gaent/service/AtdService.java
+++ b/src/main/java/com/ga/gaent/service/AtdService.java
@@ -118,7 +118,8 @@ public class AtdService {
         // 퇴근을 누르지 않은 사람들 18시로 자동등록
         int autoGetOffWorkSuccess = atdMapper.autoGetOffWork(); 
         // 출근하지 않은 사람들 NULL로 자동등록
-        int autoGetInSuccess = atdMapper.autoRegisterAtd();
+        int autoGetInSuccess = 1;
+        /* int autoGetInSuccess = atdMapper.autoRegisterAtd(); */
         
             
         log.debug(TeamColor.RED + "퇴근 자동 입력: " + autoGetOffWorkSuccess + TeamColor.RESET);


### PR DESCRIPTION
1. 출근 기록이 없는 직원들은 null값을 입력하도록 함
2. 데이터베이스에 불필요한 데이터가 쌓이는 걸 방지하기 위해 출근 기록이 없어도 null값을 입력하지 않게 로직을 수정